### PR TITLE
Ensure link usage changes are propagated

### DIFF
--- a/Pileolinks/MauiProgram.cs
+++ b/Pileolinks/MauiProgram.cs
@@ -28,6 +28,7 @@ public static class MauiProgram
 		builder.Services.AddSingleton<IDataConverter, DataConverter>();
 		builder.Services.AddSingleton<IDataService, LocalStorageDataService>();
 		builder.Services.AddSingleton<IEssentialsService, EssentialsService>();
+		builder.Services.AddSingleton<ILinkCache, LinkCache>();
 		builder.Services.AddTransient<MainPageViewModel>();
 		builder.Services.AddTransient<SearchViewModel>();
 		builder.Services.AddTransient<TreeFlyout>();

--- a/Pileolinks/Models/Link.cs
+++ b/Pileolinks/Models/Link.cs
@@ -36,13 +36,27 @@ namespace Pileolinks.Models
         public int Used
         {
             get => used;
-            set => used = value;
+            set
+            {
+                if (used != value)
+                {
+                    used = value;
+                    UsageChanged?.Invoke(this, EventArgs.Empty);
+                }
+            }
         }
 
         public DateOnly LastUsed
         {
             get => lastUsed;
-            set => lastUsed = value;
+            set
+            {
+                if (lastUsed != value)
+                {
+                    lastUsed = value;
+                    UsageChanged?.Invoke(this, EventArgs.Empty);
+                }
+            }
         }
 
         public ObservableCollection<string> Tags { get; private set; } = new(tags ?? []);
@@ -65,6 +79,7 @@ namespace Pileolinks.Models
         public event EventHandler Deleted;
         public event EventHandler<ITreeItem> Moved;
         public event EventHandler NameChanged;
+        public event EventHandler UsageChanged;
 
         public bool AddDirectory(string name)
         {

--- a/Pileolinks/Services/Interfaces/ILinkCache.cs
+++ b/Pileolinks/Services/Interfaces/ILinkCache.cs
@@ -1,0 +1,32 @@
+using Pileolinks.Components.Tree;
+using Pileolinks.Models;
+
+namespace Pileolinks.Services.Interfaces
+{
+    /// <summary>
+    /// Singleton cache that maintains a single in-memory copy of all Link and LinkDirectory objects.
+    /// Ensures all ViewModels reference the same model instances for proper event propagation.
+    /// </summary>
+    public interface ILinkCache
+    {
+        /// <summary>
+        /// Gets all top-level directories (collections).
+        /// </summary>
+        List<ITreeItem> GetTopLevelDirectories();
+
+        /// <summary>
+        /// Gets all links from all directories, recursively.
+        /// </summary>
+        List<Link> GetAllLinks();
+
+        /// <summary>
+        /// Explicitly refreshes the cache from persistent storage.
+        /// </summary>
+        void Refresh();
+
+        /// <summary>
+        /// Indicates whether the cache has been populated.
+        /// </summary>
+        bool IsInitialized { get; }
+    }
+}

--- a/Pileolinks/Services/LinkCache.cs
+++ b/Pileolinks/Services/LinkCache.cs
@@ -1,0 +1,75 @@
+using Pileolinks.Components.Tree;
+using Pileolinks.Models;
+using Pileolinks.Services.Interfaces;
+
+namespace Pileolinks.Services
+{
+    /// <summary>
+    /// Singleton cache service that maintains a single in-memory copy of all Link and LinkDirectory objects.
+    /// All ViewModels reference the same model instances through this cache, ensuring that updates
+    /// (like link usage changes) are visible across all pages without needing to reload from disk.
+    /// </summary>
+    public class LinkCache : ILinkCache
+    {
+        private readonly IDataService _dataService;
+        private List<ITreeItem> _topLevelDirectories = [];
+        private bool _isInitialized = false;
+
+        public bool IsInitialized => _isInitialized;
+
+        public LinkCache(IDataService dataService)
+        {
+            _dataService = dataService;
+        }
+
+        /// <summary>
+        /// Gets all top-level directories. Lazy-loads from persistent storage on first access.
+        /// </summary>
+        public List<ITreeItem> GetTopLevelDirectories()
+        {
+            if (!_isInitialized)
+            {
+                Refresh();
+            }
+            return _topLevelDirectories;
+        }
+
+        /// <summary>
+        /// Gets all links from all directories, recursively.
+        /// Uses a stack-based traversal to walk the entire directory tree.
+        /// </summary>
+        public List<Link> GetAllLinks()
+        {
+            List<Link> allLinks = [];
+            var topLevelDirectories = GetTopLevelDirectories();
+
+            Stack<ITreeItem> stack = new();
+            foreach (var directory in topLevelDirectories)
+            {
+                stack.Push(directory);
+            }
+
+            while (stack.Count > 0)
+            {
+                LinkDirectory directory = (LinkDirectory)stack.Pop();
+                allLinks.AddRange(directory.Descendants.Where(d => d.Type == TreeItemType.Link).Select(l => (Link)l));
+                foreach (var item in directory.Directories)
+                {
+                    stack.Push(item);
+                }
+            }
+
+            return allLinks;
+        }
+
+        /// <summary>
+        /// Explicitly refreshes the cache from persistent storage.
+        /// Called on first access or can be called manually to reload all data.
+        /// </summary>
+        public void Refresh()
+        {
+            _topLevelDirectories = _dataService.GetTopLevelTreeItems();
+            _isInitialized = true;
+        }
+    }
+}

--- a/Pileolinks/ViewModels/LinkViewModel.cs
+++ b/Pileolinks/ViewModels/LinkViewModel.cs
@@ -100,6 +100,14 @@ namespace Pileolinks.ViewModels
             {
                 Tags.Add(tag);
             }
+            link.UsageChanged += Link_UsageChanged;
+        }
+
+        private void Link_UsageChanged(object sender, EventArgs e)
+        {
+            OnPropertyChanged(nameof(UsedInformation));
+            OnPropertyChanged(nameof(Used));
+            OnPropertyChanged(nameof(LastUsed));
         }
 
         [RelayCommand]
@@ -164,7 +172,6 @@ namespace Pileolinks.ViewModels
         {
             link.Used++;
             link.LastUsed = DateOnly.FromDateTime(DateTime.Now);
-            OnPropertyChanged(nameof(UsedInformation));
             SaveCollection();
         }
 

--- a/Pileolinks/ViewModels/MainPageViewModel.cs
+++ b/Pileolinks/ViewModels/MainPageViewModel.cs
@@ -14,6 +14,7 @@ namespace Pileolinks.ViewModels
         private Command<ITreeItem> deleteDirectoryCommand;
         private Command<string> addDirectoryCommand, addCollectionCommand, renameDirectoryCommand;
         private readonly IDataService dataService;
+        private readonly ILinkCache linkCache;
 
         public event EventHandler<ITreeItem> DeleteRequested;
         public event EventHandler AddDirectoryRequested;
@@ -55,14 +56,11 @@ namespace Pileolinks.ViewModels
         public Command RequestRenameDirectoryCommand => requestRenameDirectoryCommand ??= new Command(RequestRenameDirectory);
         public Command<string> RenameDirectoryCommand => renameDirectoryCommand ??= new Command<string>(RenameDirectory);
 
-        public MainPageViewModel(IDataService dataService)
+        public MainPageViewModel(IDataService dataService, ILinkCache linkCache)
         {
             this.dataService = dataService;
-            ObservableCollection<ITreeItem> items = new();
-            foreach (ITreeItem item in dataService.GetTopLevelTreeItems())
-            {
-                items.Add(item);
-            }
+            this.linkCache = linkCache;
+            ObservableCollection<ITreeItem> items = [.. linkCache.GetTopLevelDirectories()];
             Items = items;
         }
 

--- a/Pileolinks/ViewModels/SearchViewModel.cs
+++ b/Pileolinks/ViewModels/SearchViewModel.cs
@@ -45,6 +45,7 @@ namespace Pileolinks.ViewModels
         private readonly IDataService dataService;
         private readonly ILinkViewModelFactory linkViewModelFactory;
         private readonly IEssentialsService essentialsService;
+        private readonly ILinkCache linkCache;
 
         public bool HasResultsAndIsNotLoading => SearchHasResults && !Loading;
 
@@ -63,11 +64,12 @@ namespace Pileolinks.ViewModels
         public event EventHandler<LinkViewModel> EditLinkRequested;
         public event EventHandler<LinkDirectory> OpenParentRequested;
 
-        public SearchViewModel(IDataService dataService, ILinkViewModelFactory linkViewModelFactory, IEssentialsService essentialsService) 
+        public SearchViewModel(IDataService dataService, ILinkViewModelFactory linkViewModelFactory, IEssentialsService essentialsService, ILinkCache linkCache) 
         {
             this.dataService = dataService;
             this.linkViewModelFactory = linkViewModelFactory;
             this.essentialsService = essentialsService;
+            this.linkCache = linkCache;
             Results.CollectionChanged += Results_CollectionChanged;
             SearchPerformed = false;
             SelectedSort = sorts.FirstOrDefault(s => s.SortType == SortType.Alphabetical);
@@ -205,21 +207,7 @@ namespace Pileolinks.ViewModels
         public void Arriving()
         {
             links.Clear();
-            List<ITreeItem> collections = dataService.GetTopLevelTreeItems();
-            Stack<ITreeItem> stack = new();
-            foreach (var collection in collections) 
-            {
-                stack.Push(collection);
-            }
-            while (stack.Count > 0)
-            {
-                LinkDirectory directory = (LinkDirectory)stack.Pop();
-                links.AddRange(directory.Descendants.Where(d => d.Type == TreeItemType.Link).Select(l => (Link)l));
-                foreach (var item in directory.Directories)
-                {
-                    stack.Push(item);
-                }
-            }
+            links.AddRange(linkCache.GetAllLinks());
         }
 
         public void Leaving()


### PR DESCRIPTION
Add a link cache between pages and the data service so that when link usage is updated on the search pages for instance that these changes are displayed in directory views. Previously the search page was loading its own set of link instances using the data service so the usage changes weren't propagating to other parts of the UI.